### PR TITLE
Use the rasterio travis wheel releases to speed up buids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ install:
   - pip install -U pip
   - pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache
 script:
-  - py.test --cov mbtiles --cov-report term-missing
+  - py.test --cov rio_color --cov-report term-missing
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ppa
   - sudo apt-get update -qq
   - sudo apt-get install -y libgdal1h gdal-bin
+  - curl -L https://github.com/mapbox/rasterio/releases/download/release-test-4/rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz > /tmp/wheelhouse.tar.gz
+  - tar -xzvf /tmp/wheelhouse.tar.gz -C $HOME
 install:
+  - pip install -U pip
   - pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache
 script:
   - py.test --cov mbtiles --cov-report term-missing

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,17 @@ language: python
 python:
   - "2.7"
   - "3.4"
+cache:
+  directories:
+    - $HOME/.pip-cache/
+    - $HOME/wheelhouse
 before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ppa
   - sudo apt-get update -qq
-  - sudo apt-get install -y libgdal1h gdal-bin libgdal-dev
+  - sudo apt-get install -y libgdal1h gdal-bin
 install:
-  - pip install --install-option="--no-cython-compile" cython==0.21.2
-  - "pip install -r requirements-dev.txt"
-  - "pip install git+https://github.com/mapbox/rasterio.git#egg=rasterio"
-  - "pip install -e .[test]"
-script: 
-  - py.test
+  - pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache
+script:
+  - py.test --cov mbtiles --cov-report term-missing
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # rio-color
 
+[![Build Status](https://travis-ci.org/mapbox/rio-color.svg)](https://travis-ci.org/mapbox/rio-color)
+[![Coverage Status](https://coveralls.io/repos/mapbox/rio-color/badge.svg?branch=master&service=github)](https://coveralls.io/github/mapbox/rio-color?branch=master)
+
 Color-oriented operations for `rasterio`/`rio`.
 
 ## Goals

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setup(name='rio-color',
           'rasterio>=0.23'
       ],
       extras_require={
-          'test': ['pytest'],
+          'test': ['coveralls', 'pytest', 'pytest-cov'],
       },
       entry_points="""
-      [rasterio.rio_commands]
+      [rasterio.rio_plugins]
       color=rio_color.scripts.cli:rio_color
       """      )

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -1,1 +1,2 @@
-
+def test_color():
+    assert "black" is "white"


### PR DESCRIPTION
Additionally, add coveralls and pytest-cov and register at the rio_plugins entry point.

Pretty much just the same as I'm doing in https://github.com/mapbox/rio-mbtiles/pull/11.

This is 30% ready, not to be merged.