### PR TITLE
use float64 to avoid floating point errors on arrays scaled 0.0 to 1.0

### DIFF
--- a/rio_color/utils.py
+++ b/rio_color/utils.py
@@ -5,7 +5,7 @@ import re
 # operations. Should be a float because values will
 # be scaled to the range 0..1 for all work.
 
-math_type = np.float32
+math_type = np.float64
 
 epsilon = np.finfo(math_type).eps
 


### PR DESCRIPTION
Problem with float32 - if you scale an array 0.0-1.0, then do a few maths on it you can get floating point inconsistencies (i.e. max of 1.000000001).

Float64 is far less prone to this sort of error.