### PR TITLE
DSL revisited

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The following functions accept and return numpy `ndarrays`. The arrays are assum
 * `saturation(rgb, proportion)`
 * `simple_atmo(rgb, haze, contrast, bias)`
 
-There is one function in the `rio_color.operations` module which doesn't manipulate arrays: 
+There is one function in the `rio_color.operations` module which doesn't manipulate arrays:
 `parse_operations`. This function takes an *operations string* and
-returns a list of python functions which can be applied to an array. 
+returns a list of python functions which can be applied to an array.
 
 ```
 ops = "gamma b 1.85, gamma rg 1.95, sigmoidal rgb 35 0.13, saturation 1.15"
@@ -70,7 +70,7 @@ Usage: rio color [OPTIONS] SRC_PATH DST_PATH [OPERATIONS]...
           PROPORTION = 2 is likely way too saturated
 
   BANDS are specified as a single arg
-  
+
         `123` or `RGB` or `rgb` are all equivalent
 
   Example:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following functions accept and return numpy `ndarrays`. The arrays are assum
 
 * `sigmoidal(arr, contrast, bias)`
 * `gamma(arr, g)`
-* `saturation(rgb, percent)`
+* `saturation(rgb, proportion)`
 * `simple_atmo(rgb, haze, contrast, bias)`
 
 There is one function in the `rio_color.operations` module which doesn't manipulate arrays: 
@@ -29,7 +29,7 @@ ops = [
     "gamma 3 1.85", 
     "gamma 1,2 1.95",
     "sigmoidal 1,2,3 35 0.13",
-    "saturation 115"]
+    "saturation 1.15"]
 
 # arr is an 3D numpy array, RGB, scaled 0 to 1
 
@@ -89,7 +89,7 @@ Example:
 
 ```
 $ rio color -d uint8 -j 4 rgb.tif test.tif \
-    "gamma 3 1.85" "gamma 1,2 1.95" "sigmoidal 1,2,3 35 0.13" "saturation 115"
+    "gamma 3 1.85" "gamma  1.95" "sigmoidal 1,2,3 35 0.13" "saturation 1.15"
 ```
 
 ![screen shot 2016-02-17 at 12 18 47 pm](https://cloud.githubusercontent.com/assets/1151287/13116122/0f7f5f20-d571-11e5-82e7-9cc65c443972.png)

--- a/README.md
+++ b/README.md
@@ -21,23 +21,21 @@ The following functions accept and return numpy `ndarrays`. The arrays are assum
 * `simple_atmo(rgb, haze, contrast, bias)`
 
 There is one function in the `rio_color.operations` module which doesn't manipulate arrays: 
-`parse_operations`. This function takes an iterable of *operation strings* and
-yields python functions which can be applied to an array. 
+`parse_operations`. This function takes an *operations string* and
+returns a list of python functions which can be applied to an array. 
 
 ```
-ops = [
-    "gamma 3 1.85", 
-    "gamma 1,2 1.95",
-    "sigmoidal 1,2,3 35 0.13",
-    "saturation 1.15"]
+ops = "gamma b 1.85, gamma rg 1.95, sigmoidal rgb 35 0.13, saturation 1.15"
 
-# arr is an 3D numpy array, RGB, scaled 0 to 1
+assert arr.shape[0] == 3
+assert arr.min() >= 0
+assert arr.max() <= 1
 
 for func in parse_operations(ops):
     arr = func(arr)
 ```
 
-This provides a tiny *domain specific language* to allow you
+This provides a tiny domain specific language (DSL) to allow you
 to compose ordered chains of image manipulations using the above operations.
 For more information on operation strings, see the `rio color` command line help.
 
@@ -65,18 +63,20 @@ Usage: rio color [OPTIONS] SRC_PATH DST_PATH [OPERATIONS]...
       "sigmoidal BANDS CONTRAST BIAS"
           Adjusts the contrast and brightness of midtones.
 
-      "saturation PERCENTAGE"
-          Controls the saturation in HSV color space.
-          PERCENTAGE = 0 results in a grayscale image
+      "saturation PROPORTION"
+          Controls the saturation in LCH color space.
+          PROPORTION = 0 results in a grayscale image
+          PROPORTION = 1 results in an identical image
+          PROPORTION = 2 is likely way too saturated
 
-  BANDS are specified as a comma-separated list of band numbers or letters
-
-      `1,2,3` or `R,G,B` or `r,g,b` are all equivalent
+  BANDS are specified as a single arg
+  
+        `123` or `RGB` or `rgb` are all equivalent
 
   Example:
 
       rio color -d uint8 -j 4 input.tif output.tif \
-          "gamma 3 0.95" "sigmoidal 1,2,3 35 0.13"
+          gamma b 0.95 sigmoidal rgb 35 0.13
 
 
 Options:
@@ -89,7 +89,7 @@ Example:
 
 ```
 $ rio color -d uint8 -j 4 rgb.tif test.tif \
-    "gamma 3 1.85" "gamma  1.95" "sigmoidal 1,2,3 35 0.13" "saturation 1.15"
+    gamma G 1.85 gamma B 1.95 sigmoidal RGB 35 0.13 saturation 1.15
 ```
 
 ![screen shot 2016-02-17 at 12 18 47 pm](https://cloud.githubusercontent.com/assets/1151287/13116122/0f7f5f20-d571-11e5-82e7-9cc65c443972.png)

--- a/rio_color/operations.py
+++ b/rio_color/operations.py
@@ -166,13 +166,12 @@ def simple_atmo(rgb, haze, contrast, bias):
     return output
 
 
-def parse_operations(operations):
-    """Takes an iterable of operations,
-    each operation is expected to be a string with a specified syntax
+def parse_operations(ops_string):
+    """Takes a string of operations written with a handy DSL
 
-    "OPERATION-NAME BANDS ARGS..."
+    "OPERATION-NAME BANDS ARG1 ARG2 OPERATION-NAME BANDS ARG"
 
-    And yields a list of functions that take and return ndarrays
+    And returns a list of functions, each of which take and return ndarrays
     """
     band_lookup = {'r': 1, 'g': 2, 'b': 3}
     count = len(band_lookup)
@@ -190,8 +189,21 @@ def parse_operations(operations):
     # Operations that assume RGB colorspace
     rgb_ops = ('saturation',)
 
-    for op in operations:
-        parts = op.split(" ")
+    # split into tokens, commas are optional whitespace
+    tokens = [x.strip() for x in ops_string.replace(',', '').split(' ')]
+    operations = []
+    current = []
+    for token in tokens:
+        if token.lower() in opfuncs.keys():
+            if len(current) > 0:
+                operations.append(current)
+                current = []
+        current.append(token.lower())
+    if len(current) > 0:
+        operations.append(current)
+
+    result = []
+    for parts in operations:
         opname = parts[0]
         bandstr = parts[1]
         args = parts[2:]
@@ -210,7 +222,7 @@ def parse_operations(operations):
             # 2nd arg is bands
             # parse r,g,b ~= 1,2,3
             bands = set()
-            for bs in bandstr.split(","):
+            for bs in bandstr:
                 try:
                     band = int(bs)
                 except ValueError:
@@ -238,4 +250,6 @@ def parse_operations(operations):
                     newarr[b - 1] = func(arr[b - 1], **kwargs)
             return newarr
 
-        yield f
+        result.append(f)
+
+    return result

--- a/rio_color/operations.py
+++ b/rio_color/operations.py
@@ -115,22 +115,22 @@ def gamma(arr, g):
         return output
 
 
-def saturation(arr, percent):
+def saturation(arr, proportion):
     """Apply saturation to an RGB array (in LCH color space)
 
-    Multiply saturation by percent in LCH color space to adjust the intensity
+    Multiply saturation by proportion in LCH color space to adjust the intensity
     of color in the image. As saturation increases, colors appear
     more "pure." As saturation decreases, colors appear more "washed-out."
 
     Parameters
     ----------
     arr: ndarray with shape (3, ..., ...)
-    percent: integer
+    proportion: number
 
     """
     if arr.shape[0] != 3:
         raise ValueError("saturation requires a 3-band array")
-    return saturate_rgb(arr, percent / 100.0)
+    return saturate_rgb(arr, proportion)
 
 
 def simple_atmo(rgb, haze, contrast, bias):
@@ -182,7 +182,7 @@ def parse_operations(ops_string):
         'gamma': gamma}
 
     opkwargs = {
-        'saturation': ('percent',),
+        'saturation': ('proportion',),
         'sigmoidal': ('contrast', 'bias'),
         'gamma': ('g',)}
 

--- a/rio_color/scripts/cli.py
+++ b/rio_color/scripts/cli.py
@@ -76,18 +76,17 @@ Example:
     out_dtype = out_dtype if out_dtype else opts['dtype']
     opts['dtype'] = out_dtype
 
+    args = {
+        'ops_string': ' '.join(operations),
+        'out_dtype': out_dtype
+    }
     # Just run this for validation this time
     # parsing will be run again within the worker
     # where its returned value will be used
     try:
-        list(parse_operations(operations))
+        parse_operations(args['ops_string'])
     except ValueError as e:
         raise click.UsageError(str(e))
-
-    args = {
-        'operations': operations,
-        'out_dtype': out_dtype
-    }
 
     jobs = check_jobs(jobs)
 

--- a/rio_color/scripts/cli.py
+++ b/rio_color/scripts/cli.py
@@ -27,7 +27,7 @@ def check_jobs(jobs):
               help="Integer data type for output data, default: same as input")
 @click.argument('src_path', type=click.Path(exists=True))
 @click.argument('dst_path', type=click.Path(exists=False))
-@click.argument('operations', nargs=-1)
+@click.argument('operations', nargs=-1, required=True)
 @click.pass_context
 @creation_options
 def color(ctx, jobs, out_dtype, src_path, dst_path, operations,
@@ -85,7 +85,7 @@ Example:
     # parsing will be run again within the worker
     # where its returned value will be used
     try:
-        parse_operations(args['ops_string'])
+        ops = parse_operations(args['ops_string'])
     except ValueError as e:
         raise click.UsageError(str(e))
 

--- a/rio_color/scripts/cli.py
+++ b/rio_color/scripts/cli.py
@@ -50,21 +50,22 @@ Available OPERATIONS include:
         BIAS > 0.5 darkens the image.
 
 \b
-    "saturation PERCENTAGE"
-        Controls the saturation in LCH color space (similar to HSV).
-        PERCENTAGE = 0 results in a grayscale image, 100 is no change,
-        and 200 is a lot.
+    "saturation PROPORTION"
+        Controls the saturation in LCH color space.
+        PROPORTION = 0 results in a grayscale image
+        PROPORTION = 1 results in an identical image
+        PROPORTION = 2 is likely way too saturated
 
-BANDS are specified as a comma-separated list of band numbers or letters:
+BANDS are specified as a single arg
 
 \b
-    `1,2,3` or `R,G,B` or `r,g,b` are all equivalent
+    `123` or `RGB` or `rgb` are all equivalent
 
 Example:
 
 \b
     rio color -d uint8 -j 4 input.tif output.tif \\
-        "gamma 3 0.95" "sigmoidal 1,2,3 35 0.13"
+        gamma 3 0.95 sigmoidal 1,2,3 35 0.13
     """
     with rasterio.open(src_path) as src:
         opts = src.profile.copy()

--- a/rio_color/utils.py
+++ b/rio_color/utils.py
@@ -35,7 +35,7 @@ def magick_to_rio(convert_opts):
 
     Returns
     -------
-    tuple, ordered rio color operations
+    operations string, ordered rio color operations
     """
     ops = []
     bands = None
@@ -43,7 +43,7 @@ def magick_to_rio(convert_opts):
     def set_band(x):
         global bands
         if x.upper() == "RGB":
-            x = "R,G,B"
+            x = "RGB"
         bands = x.upper()
 
     set_band("RGB")
@@ -86,4 +86,4 @@ def magick_to_rio(convert_opts):
                 nextf(part)
             nextf = None
 
-    return tuple(ops)
+    return ' '.join(ops)

--- a/rio_color/utils.py
+++ b/rio_color/utils.py
@@ -66,7 +66,9 @@ def magick_to_rio(convert_opts):
     def append_sat(arg):
         args = list(filter(None, re.split("[,x]+", arg)))
         # ignore args[0]
-        ops.append("saturation {}".format(args[1]))
+        # convert to proportion
+        prop = float(args[1]) / 100
+        ops.append("saturation {}".format(prop))
 
     nextf = None
     for part in convert_opts.strip().split(" "):

--- a/rio_color/workers.py
+++ b/rio_color/workers.py
@@ -23,7 +23,7 @@ def color_worker(srcs, window, ij, args):
     arr = src.read(window=window)
     arr = to_math_type(arr)
 
-    for func in parse_operations(args['operations']):
+    for func in parse_operations(args['ops_string']):
         arr = func(arr)
 
     # scaled 0 to 1, now scale to outtype

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,7 @@ def test_color_cli(tmpdir):
             "gamma 3 1.85",
             "gamma 1,2 1.95",
             "sigmoidal 1,2,3 35 0.13",
-            "saturation 115"]
+            "saturation 1.15"]
         )
     assert result.exit_code == 0
     assert os.path.exists(output)
@@ -78,7 +78,7 @@ def test_color_cli(tmpdir):
             "gamma 3 1.85",
             "gamma 1,2 1.95",
             "sigmoidal 1,2,3 35 0.13",
-            "saturation 115"]
+            "saturation 1.15"]
         )
     assert result.exit_code == 0
     assert os.path.exists(output2)
@@ -184,7 +184,7 @@ def test_color_cli_rgba(tmpdir):
             "gamma 3 1.85",
             "gamma 1,2 1.95",
             "sigmoidal 1,2,3 35 0.13",
-            "saturation 115"]
+            "saturation 1.15"]
         )
     assert result.exit_code == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -212,3 +212,18 @@ def test_color_cli_16bit_photointerp(tmpdir):
         with rasterio.open(output) as out:
             for b in src.indexes:
                 assert out.colorinterp(b) == src.colorinterp(b)
+
+
+def test_color_empty_operations(tmpdir):
+    output = str(tmpdir.join('color.tif'))
+    runner = CliRunner()
+    result = runner.invoke(
+        color,
+        ['tests/rgb8.tif', output])
+    assert result.exit_code == 2
+    assert not os.path.exists(output)
+
+    result = runner.invoke(
+        color,
+        ['tests/rgb8.tif', output, ", , ,"])
+    assert result.exit_code == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,7 +113,7 @@ def test_color_jobsn1(tmpdir):
             '-j', '-1',
             'tests/rgb8.tif',
             output,
-            "gamma 1,2,3 1.85"])
+            "gamma 1,2,3 1.85 sigmoidal rgb 35 0.13"])
     assert result.exit_code == 0
     assert os.path.exists(output)
 
@@ -134,7 +134,7 @@ def test_creation_opts(tmpdir):
             '--co', 'compress=jpeg',
             'tests/rgb8.tif',
             output,
-            "gamma 1,2,3 1.85"])
+            "gamma 1,2,3 1.85 sigmoidal rgb 35 0.13"])
     assert result.exit_code == 0
 
     with rasterio.open(output, 'r') as src:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -76,7 +76,6 @@ def test_gamma(arr):
         x = gamma(arr, np.nan)
 
 
-
 def test_sat(arr):
     x = saturation(arr, 50)
     assert x[0][0][0] - 0.15860622 < 1e-4
@@ -104,32 +103,39 @@ def test_atmo(arr):
 
 
 def test_parse_gamma(arr):
-    f = list(parse_operations(["gamma 1,2,3 0.95", ]))[0]
+    f = parse_operations("gamma rgb 0.95")[0]
     assert np.array_equal(f(arr), gamma(arr, 0.95))
 
 
 def test_parse_sigmoidal(arr):
-    f = list(parse_operations(["sigmoidal 1,2,3 5 0.53", ]))[0]
+    f = parse_operations("sigmoidal rgb 5 0.53")[0]
     assert np.array_equal(
         f(arr),
         sigmoidal(arr, contrast=5, bias=0.53))
 
 
 def test_parse_multi(arr):
-    f1, f2 = list(parse_operations([
-        "gamma 1,2,3 0.95", "sigmoidal 1,2,3 35 0.13"]))
+    f1, f2 = parse_operations("gamma rgb 0.95 sigmoidal rgb 35 0.13")
+    assert np.array_equal(
+        f2(f1(arr)),
+        sigmoidal(gamma(arr, g=0.95), contrast=35, bias=0.13))
+
+
+def test_parse_comma(arr):
+    # Commas are optional whitespace, treated like empty string
+    f1, f2 = parse_operations("gamma r,g,b 0.95, sigmoidal r,g,b 35 0.13")
     assert np.array_equal(
         f2(f1(arr)),
         sigmoidal(gamma(arr, g=0.95), contrast=35, bias=0.13))
 
 
 def test_parse_saturation_rgb(arr):
-    f = list(parse_operations(["saturation 125", ]))[0]
+    f = parse_operations("saturation 125")[0]
     assert np.allclose(f(arr), saturation(arr, 125))
 
 
 def test_parse_rgba(arr, arr_rgba):
-    f = list(parse_operations(["gamma r,g 0.95", ]))[0]
+    f = parse_operations("gamma rg 0.95")[0]
     rgb = f(arr)
     assert rgb.shape[0] == 3
 
@@ -142,7 +148,7 @@ def test_parse_rgba(arr, arr_rgba):
 
 
 def test_saturation_rgba(arr, arr_rgba):
-    f = list(parse_operations(["saturation 125", ]))[0]
+    f = parse_operations("saturation 125")[0]
 
     satrgb = f(arr)
     assert satrgb.shape[0] == 3
@@ -158,13 +164,13 @@ def test_saturation_rgba(arr, arr_rgba):
 
 def test_parse_bad_op():
     with pytest.raises(ValueError):
-        list(parse_operations(["foob 123"]))
+        parse_operations("foob 123")
 
 
 def test_parse_bands(arr):
-    fa = list(parse_operations(["gamma 1,2 0.95", ]))[0]
-    fb = list(parse_operations(["gamma R,g 0.95", ]))[0]
+    fa = parse_operations("gamma 1,2 0.95")[0]
+    fb = parse_operations("gamma Rg 0.95")[0]
     assert np.array_equal(fa(arr), fb(arr))
 
     with pytest.raises(ValueError):
-        list(parse_operations(["gamma 7,8,9 1.05"]))
+        parse_operations("gamma 7,8,9 1.05")

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -130,8 +130,8 @@ def test_parse_comma(arr):
 
 
 def test_parse_saturation_rgb(arr):
-    f = parse_operations("saturation 125")[0]
-    assert np.allclose(f(arr), saturation(arr, 125))
+    f = parse_operations("saturation 1.25")[0]
+    assert np.allclose(f(arr), saturation(arr, 1.25))
 
 
 def test_parse_rgba(arr, arr_rgba):
@@ -148,7 +148,7 @@ def test_parse_rgba(arr, arr_rgba):
 
 
 def test_saturation_rgba(arr, arr_rgba):
-    f = parse_operations("saturation 125")[0]
+    f = parse_operations("saturation 1.25")[0]
 
     satrgb = f(arr)
     assert satrgb.shape[0] == 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,16 +51,14 @@ def test_magick_to_rio():
         "-modulate 222,135 "
     )
 
-    expected = (
+    assert ops == ' '.join([
         "sigmoidal B 4 0.5",
         "gamma B 0.95",
         "gamma R 1.10",
-        "sigmoidal R,G,B 1 0.55",
+        "sigmoidal RGB 1 0.55",
         "gamma G 0.9",
         "saturation 125",
-        "sigmoidal R,G,B 3 0.4",
+        "sigmoidal RGB 3 0.4",
         "saturation 135",
-    )
+    ])
 
-    for op, ex in zip(ops, expected):
-        assert op == ex

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,8 +57,8 @@ def test_magick_to_rio():
         "gamma R 1.10",
         "sigmoidal RGB 1 0.55",
         "gamma G 0.9",
-        "saturation 125",
+        "saturation 1.25",
         "sigmoidal RGB 3 0.4",
-        "saturation 135",
+        "saturation 1.35",
     ])
 

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -38,7 +38,7 @@ def test_atmos():
 def test_color():
     i = 77
     args = {
-        'operations': ['gamma 3 0.95', 'gamma 1,2 0.99'],
+        'ops_string': 'gamma 3 0.95 gamma 1,2 0.99',
         'out_dtype': 'uint8'}
 
     with rasterio.open('tests/rgb8.tif') as src:


### PR DESCRIPTION
Rethinking the DSL due to quoting and space delimiter issues

Old way
```
rio color in.tif out.tif "gamma r,g 1.85" "saturation 125"
```

New way
```
rio color in.tif out.tif gamma rg 1.85, saturation 1.25
```

* no quotes
* no commas to separate bands (you can use commas as empty strings to help break up the sequence but they are strictly optional)
* saturation takes a proportion, not a percentage

fixes #23 

/cc @sgillies @celoyd 