### PR TITLE
fix operation order bug

### DIFF
--- a/rio_color/operations.py
+++ b/rio_color/operations.py
@@ -183,6 +183,7 @@ def _op_factory(func, kwargs, opname, bands, rgb_op=False):
                 newarr[b - 1] = func(arr[b - 1], **kwargs)
         return newarr
 
+    f.__name__ = opname
     return f
 
 

--- a/rio_color/operations.py
+++ b/rio_color/operations.py
@@ -183,7 +183,7 @@ def _op_factory(func, kwargs, opname, bands, rgb_op=False):
                 newarr[b - 1] = func(arr[b - 1], **kwargs)
         return newarr
 
-    f.__name__ = opname
+    f.__name__ = str(opname)
     return f
 
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -181,3 +181,9 @@ def test_parse_multi_saturation_first(arr):
     assert np.array_equal(
         f2(f1(arr)),
         gamma(saturation(arr, 1.25), g=0.95))
+
+
+def test_parse_multi_name(arr):
+    f1, f2 = parse_operations("saturation 1.25 gamma rgb 0.95")
+    assert f1.__name__ == 'saturation'
+    assert f2.__name__ == 'gamma'

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -174,3 +174,10 @@ def test_parse_bands(arr):
 
     with pytest.raises(ValueError):
         parse_operations("gamma 7,8,9 1.05")
+
+
+def test_parse_multi_saturation_first(arr):
+    f1, f2 = parse_operations("saturation 1.25 gamma rgb 0.95")
+    assert np.array_equal(
+        f2(f1(arr)),
+        gamma(saturation(arr, 1.25), g=0.95))


### PR DESCRIPTION
the way I was creating operation closures had some scope issues. I moved to a [factory pattern](https://eev.ee/blog/2011/04/24/gotcha-python-scoping-closures/#the-solution) which is much cleaner and removes the potential for order bugs.

Bonus: functions now have a proper `__name__` rather than f

Fixes #25 