### PR TITLE
Explicitly set color interpretation

### DIFF
--- a/rio_color/scripts/cli.py
+++ b/rio_color/scripts/cli.py
@@ -110,6 +110,8 @@ Example:
                     arr = color_worker(rasters, window, ij, args)
                     dest.write(arr, window=window)
 
+                dest.colorinterp = src.colorinterp
+
 
 @click.command('atmos')
 @click.option('--atmo', '-a', type=click.FLOAT, default=0.03,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,8 +211,7 @@ def test_color_cli_16bit_photointerp(tmpdir):
 
     with rasterio.open('tests/rgb16.tif') as src:
         with rasterio.open(output) as out:
-            for b in src.indexes:
-                assert out.colorinterp == src.colorinterp
+            assert out.colorinterp == src.colorinterp
 
 
 def test_color_empty_operations(tmpdir):


### PR DESCRIPTION
Previously we were counting on creation keyword storage that is gone from Rasterio 1.0.

Resolves #51