### PR TITLE
Example wheel builds using cibuildwheel

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -58,7 +58,9 @@ jobs:
           python-version: '3.7'
 
       - name: Build sdist
-        run: python setup.py sdist
+        run: |
+          python -m pip install numpy Cython
+          python setup.py sdist
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,80 @@
+name: Build Wheels
+
+# Only run on new tags starting with `v`
+# on:
+#   push:
+#     tags:
+#       - 'v*'
+on: [push]
+
+jobs:
+  build_wheels:
+    name: Build wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: set environment variables
+      uses: allenevans/set-env@v1.1.0
+      with:
+        CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+        CIBW_BEFORE_BUILD: python -m pip install numpy Cython
+
+    - uses: actions/setup-python@v1
+      name: Install Python
+      with:
+        python-version: '3.7'
+
+    - name: Install cibuildwheel
+      run: |
+        python -m pip install cibuildwheel==1.4.2
+
+    - name: Install Visual C++ for Python 2.7
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        choco install vcpython27 -f -y
+
+    - name: Build wheel
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}
+          # To test: repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
:wave:

In `rio-tiler` we're considering adding a dependency on `rio-color` and I saw #65. I've had a lot of success using the https://github.com/joerick/cibuildwheel project, which uses a CI platform of your choice to simplify the wheel-building process (especially for simple wheels that don't have any complex dependencies). I thought it might help to move the conversation forward to share a working example. This example uses Github Actions but it should be possible to use Travis CI instead if you wish.

This ran on my fork and created the following set of wheels: [artifact.zip](https://github.com/mapbox/rio-color/files/5466520/artifact.zip). (I'm not totally sure why it didn't build wheels for 3.9; a [similar script](https://github.com/kylebarron/pydelatin/blob/a68364f9a041d1781d9f3375211fca318b9a0aa8/.github/workflows/build-wheels.yml#L25) did [build 3.9 wheels](https://pypi.org/project/pydelatin/#files) for me).

