### PR TITLE
Add numpy as setup requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     ext_modules=ext_modules,
     include_dirs=include_dirs,
     extras_require={"test": ["pytest", "colormath==2.0.2", "pytest-cov", "codecov"]},
-    setup_requires=['numpy'],
+    setup_requires=["numpy"],
     entry_points="""
     [rasterio.rio_plugins]
     color=rio_color.scripts.cli:color

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ class get_numpy_include:
 
 
 include_dirs = [
-    # Path to pybind11 headers
     get_numpy_include()
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,22 @@ try:
 except ImportError:
     cythonize = None
 
-include_dirs = []
-try:
-    import numpy
 
-    include_dirs.append(numpy.get_include())
-except ImportError:
-    print("Numpy and its headers are required to run setup(). Exiting.")
-    sys.exit(1)
+class get_numpy_include:
+    """Helper class to determine the numpy include path
+    The purpose of this class is to postpone importing numpy
+    until it is actually installed, so that the ``get_include()``
+    method can be invoked. """
 
+    def __str__(self):
+        import numpy
+        return numpy.get_include()
+
+
+include_dirs = [
+    # Path to pybind11 headers
+    get_numpy_include()
+]
 
 # Parse the version from the fiona module.
 with open("rio_color/__init__.py") as f:
@@ -90,6 +97,7 @@ setup(
     ext_modules=ext_modules,
     include_dirs=include_dirs,
     extras_require={"test": ["pytest", "colormath==2.0.2", "pytest-cov", "codecov"]},
+    setup_requires=['numpy'],
     entry_points="""
     [rasterio.rio_plugins]
     color=rio_color.scripts.cli:color

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,15 @@ except ImportError:
     cythonize = None
 
 
-class get_numpy_include:
-    """Helper class to determine the numpy include path
-    The purpose of this class is to postpone importing numpy
-    until it is actually installed, so that the ``get_include()``
-    method can be invoked. """
+def get_numpy_include():
+    """Helper function to find the numpy include path
 
-    def __str__(self):
-        import numpy
-        return numpy.get_include()
+    The purpose of this function is to postpone importing numpy
+    until it is actually installed, so that the get_include()
+    method can be invoked.
+    """
+    import numpy
+    yield numpy.get_include()
 
 
 include_dirs = [


### PR DESCRIPTION
We got a [downstream bug report](https://github.com/developmentseed/titiler/issues/158) of `rio-color`'s install failing because the user didn't have `numpy` installed when he tried to install `rio-color`, so the headers couldn't be found.

This is a bit of a chicken-and-egg issue, because the numpy headers are needed to build, but you can't find them before installing numpy. This PR uses a technique I learned from [`pybind11`](https://pybind11.readthedocs.io/en/stable/index.html) (though I can't find now exactly where in the documentation it was referenced), which uses a class to postpone finding numpy's headers until numpy is installed.

Tested locally (using conda just to create a virtual env):

Setup: 
```
> conda create -n minimal-test -c conda-forge python -y
> source activate minimal-test
```

Before:

```
> python setup.py bdist_wheel
Numpy and its headers are required to run setup(). Exiting.
```

After, creating the wheel works.