### PR TITLE
Update numpy dependency to reflect ABI change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ env:
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
 
 python:
-  - "2.7"
-  - "3.6"
+  - "3.7"
 
 before_install:
   - pip install -U pip
@@ -23,7 +22,7 @@ install:
   - pip install -e .[test]
 
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pre-commit run --all-files; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pre-commit run --all-files; fi
   - python -m pytest --cov rio_color --cov-report term-missing
 
 after_success:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ cligj
 colormath==2.0.2
 coveralls>=0.4
 delocate
-numpy>=1.8.0
+numpy>=1.20.0
 pre-commit
 pytest~=3.10.0
 pytest-cov>=2.2.0


### PR DESCRIPTION
When I ran `pip3 install rio-color` on a Debian system that had numpy 1.19.5 and Python 3.9 installed, it seems to have downloaded a rio-color wheel that was built against a newer version of numpy that broke backwards ABI compatibility. That resulted in a "ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject", which led me to this page: https://stackoverflow.com/questions/66060487/valueerror-numpy-ndarray-size-changed-may-indicate-binary-incompatibility-exp

I know this isn't the most ideal change to make, but I figure it might help people in a similar situation in the future?