### PR TITLE
Upgrade cython to support python 3.11+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools",
   "wheel",
-  "cython==0.29.21",
+  "cython==0.29.32",
   "oldest-supported-numpy; python_version >= '3.5'",
   "numpy; python_version < '3.5'"
 ]


### PR DESCRIPTION
Upgrade cython to allow building on python 3.11.

Fix in cython: https://github.com/cython/cython/pull/4428