### PR TITLE
Bump numpy to v2 because of python v3.9

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,7 @@ Changes
 - Bump rasterio to 1.4.
 - Bump colormath to 3.0.
 - Bump click to 8.1.
-- Bump numpy to 1.26.
+- Bump numpy to 2.0.2.
 - Bump Cython to 3.0.
 - Bump pytest to 8.3.
 - TravisCI --> GHA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ requires = [
   "setuptools",
   "wheel",
   "cython==3.0.11",
-  "numpy==1.26.0"
+  "numpy==2.0.2"
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ affine
 cligj
 colormath==3.0.0
 delocate
-numpy==1.26.0
+numpy==2.0.2
 pre-commit
 pytest~=8.3.4
 pytest-cov>=2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click~=8.1
-numpy==1.26.0
+numpy==2.0.2
 rasterio~=1.4
 rio-mucho


### PR DESCRIPTION
Per @vincentsarago's suggestion, which of course immediately worked locally. https://github.com/mapbox/rio-color/pull/92#issuecomment-2546459891 